### PR TITLE
Don't chain response when makeCredential() is called using long APDU

### DIFF
--- a/src/main/java/us/q3q/fido2/FIDO2Applet.java
+++ b/src/main/java/us/q3q/fido2/FIDO2Applet.java
@@ -1151,7 +1151,13 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
             outputLen += 32;
         }
 
-        doSendResponse(apdu, outputLen);
+        if (apdu.getOffsetCdata() == ISO7816.OFFSET_EXT_CDATA) {
+            apdu.setOutgoing();
+            apdu.setOutgoingLength(outputLen);
+            apdu.sendBytesLong(bufferMem, (short) 0, outputLen);
+        } else {
+            doSendResponse(apdu, outputLen);
+        }
     }
 
 


### PR DESCRIPTION
makeCredential() would always return a chained response, even if extended APDU is used to invoke the command. This is not compliant with the specification and would fail with iOS 17 Beta (and with earlier versions as well, I suppose).

This PR would simply force the response to be sent in one shot if makeCredential() is called using extended APDU, which would fix that command for iOS 17 Beta.

Merging this PR together with #3 would cause FIDO2Applet to start working correctly with iOS 17 Beta (tested with J3H145).