### PR TITLE
Fixed typo in get_install_parameters.py

### DIFF
--- a/get_install_parameters.py
+++ b/get_install_parameters.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
         'buffer_mem',
         'flash_scratch',
         'do_not_store_pin_length',
-        'cache_pin_tokens',
+        'cache_pin_token',
         'certification_level'
     ]):
         val = getattr(args, option_string)


### PR DESCRIPTION
A typo on line 63 "cache_pin_token[s]" will cause the script to crash with AttributeError: 'Namespace' object has no attribute 'cache_pin_tokens'. Did you mean: 'cache_pin_token'?