### PR TITLE
Relax the P1P2 for U2F_REGISTER

### DIFF
--- a/src/main/java/us/q3q/fido2/FIDO2Applet.java
+++ b/src/main/java/us/q3q/fido2/FIDO2Applet.java
@@ -3560,7 +3560,7 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
             return;
         }
 
-        if (cla_ins == 0x0001 && p1_p2 == 0x0000) {
+        if (cla_ins == 0x0001) {
             transientStorage.clearOutgoingContinuation();
             u2FRegister(apdu);
             return;


### PR DESCRIPTION
The hwsecurity SDK does not set P1P2 to zero.