### PR TITLE
Add bin directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build
 /venv
 __pycache__
+/bin


### PR DESCRIPTION
I am not quite sure why my build system adds and populates this directory with class files, but it does. These should not be checked in obviously. 