### PR TITLE
Remove obsolete entries from MDS3 statement

### DIFF
--- a/mds.json
+++ b/mds.json
@@ -13,7 +13,6 @@
     { "major": 1, "minor": 0 }
   ],
   "authenticationAlgorithms": ["secp256r1_ecdsa_sha256_der"],
-  "assertionScheme": "FIDOV2",
   "publicKeyAlgAndEncodings": ["cose"],
   "attestationTypes": ["basic_full"],
   "userVerificationDetails": [
@@ -27,8 +26,6 @@
   "keyProtection": ["hardware", "secure_element"],
   "matcherProtection": ["on_chip"],
   "isFreshUserVerificationRequired": true,
-  "isSecondFactorOnly": false,
-  "operatingEnv": "Secure Element (SE)",
   "cryptoStrength": 128,
   "attachmentHint": ["nfc", "wireless"],
   "supportedExtensions": [


### PR DESCRIPTION
Just a quick heads up, according to https://medium.com/webauthnworks/webauthn-fido2-whats-new-in-mds3-migrating-from-mds2-to-mds3-a271d82cb774 and the latest MDS spec https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html a few entries have been removed.