### PR TITLE
Specify package ID and AID via gradle properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,11 +63,11 @@ if (jcHomeSet) {
             cap {
                 packageName 'us.q3q.fido2'
                 version '0.1'
-                aid 'A0:00:00:06:47'
+                aid PackageID
                 output 'FIDO2.cap'
                 applet {
                     className 'us.q3q.fido2.FIDO2Applet'
-                    aid 'A0:00:00:06:47:2F:00:01'
+                    aid ApplicationID
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+PackageID='A0:00:00:06:47'
+ApplicationID='A0:00:00:06:47:2F:00:01'


### PR DESCRIPTION
This allows the user to set desired cap IDs and application IDs directly via the command line when invoking Gradle, i.e. `./gradlew -PPackageID='...' -PApplicationID='...' buildJavaCard `.

Rationale: Fidesmo only grants a narrow set of AID permissions, which also apply to CAP IDs.