### PR TITLE
Fix ID format in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-PackageID='A0:00:00:06:47'
-ApplicationID='A0:00:00:06:47:2F:00:01'
+PackageID=A000000647
+ApplicationID=A0000006472F0001


### PR DESCRIPTION
In `gradle.properties`, the IDs must be specified without quotation marks, those would convert to additional `FF`  prefixes and suffixes.