### PR TITLE
Fix crash on applet select, properly handle subsequent selects

### DIFF
--- a/src/main/java/us/q3q/fido2/FIDO2Applet.java
+++ b/src/main/java/us/q3q/fido2/FIDO2Applet.java
@@ -3448,10 +3448,9 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
             transientStorage.disableAuthenticator();
         }
 
-        if (cla_ins == (short) 0x00A4 && p1_p2 == (short) 0x0400) {
+        if (cla_ins == (short) 0x00A4 && apduBytes[ISO7816.OFFSET_P1] == 0x04) {
             // Applet-select command, probably part of test shenanigans
-            handleAppletSelect(apdu);
-            return;
+            throwException(ISO7816.SW_FILE_NOT_FOUND);
         }
 
         if (transientStorage.authenticatorDisabled()) {
@@ -4319,11 +4318,6 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
      */
     private void handleAppletSelect(APDU apdu) {
         apdu.setIncomingAndReceive();
-
-        if (!JCSystem.getAID().equals(apdu.getBuffer(), apdu.getOffsetCdata(), (byte) apdu.getIncomingLength())) {
-            throwException(ISO7816.SW_FILE_NOT_FOUND);
-        }
-
         if (bufferManager == null) {
             // There also might not be enough RAM, quite, if we allocate this during install while the app install
             // parameters array is held in memory...


### PR DESCRIPTION
This is a response to #32 .

Did you test the patch on a P71 chip? For me the applet selection now always crashes the applet with `6F 00`. I suspect the API `JCSystem.getAID()` is unavailable. 

According to https://docs.oracle.com/javacard/3.0.5/api/javacard/framework/Applet.html#selectingApplet() , `selectingApplet()` is used "to distinguish the SELECT APDU command which selected this applet, from all other SELECT APDU commands". This means that we should just be able to swallow up any subsequent select command after checking `selectingApplet()` in `process()` afaik.

I propose a simpler fix: just throw `SW_FILE_NOT_FOUND` if a select command is found after  `selectingApplet()` has returned false.