### PR TITLE
fix: preserve uniqueRP flag during credential overwrite

### DIFF
--- a/src/main/java/us/q3q/fido2/FIDO2Applet.java
+++ b/src/main/java/us/q3q/fido2/FIDO2Applet.java
@@ -1054,14 +1054,16 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
                     if (!foundRPMatchInRKs) {
                         uniqueRP = true;
                     }
-                } else if (targetRKSlot < (short)(numResidentCredentials - 1)) {
+                } else {
+                    uniqueRP = residentKeys[targetRKSlot].isUniqueRP();                    
+                    if (targetRKSlot < (short)(numResidentCredentials - 1)) {
                     // We need to put the credential at the end of the list so it's still the "most recent" one
                     for (short i = targetRKSlot; i < (short)(numResidentCredentials - 1); i++) {
                         residentKeys[i] = residentKeys[(short)(i + 1)];
                     }
                     targetRKSlot = (short)(numResidentCredentials - 1);
                 }
-
+               }
                 byte effectiveCredBlobLen = credBlobLen;
                 if (effectiveCredBlobLen > MAX_CRED_BLOB_LEN) {
                     // Ignore


### PR DESCRIPTION
Bug: When overwriting an existing resident key, the applet performs an array shift but fails to inherit the  flag from the old credential. This causes the flag to default to . As a result, all credentials under that RP become completely invisible to credential management apps.



https://github.com/BryanJacobs/FIDO2Applet/issues/50