### PR TITLE
Allow for safe extended-length SELECT

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ If you're a really detail-oriented person, you might enjoy reading
 
 | Application         | Status                         |
 |---------------------|--------------------------------|
-| Chrome on Android   | CTAP1 Only (Play Services [1]) |
+| Chrome on Android   | Working [1]                    |
 | Chrome on Linux     | Working, USBHID only [2]       |
 | Chrome on Windows   | Working                        |
-| Fennec on Android   | CTAP1 Only (Play Services [1]) |
+| Fennec on Android   | Working (Play Services [1])    |
 | WebView on Android  | Working                        |
 | Firefox on Linux    | Working, USBHID only [2]       |
 | Firefox on Windows  | Working                        |
@@ -176,14 +176,21 @@ If you're a really detail-oriented person, you might enjoy reading
 | FIDOk               | Working                        |
 
 There are two compatibility issues in the table above:
-1. Google Play Services on Android contains a complete webauthn implementation, but it appears to be
-   hardwired to use only "passkeys". If a site explicitly requests a *non-discoverable* credential,
-   you will be prompted to use an NFC security key, but this is only CTAP1 and not CTAP2. There's
-   nothing fundamentally preventing this from working on Android but the current state of Chrome
-   and Fennec are that CTAP2 doesn't, because both use the broken Play Services library. MicroG has
-   a fully-working implementation, though! See https://github.com/microg/GmsCore/pull/2194 for PIN
-   support.
-1. Some browsers support FIDO2 in theory but only allow USB security keys - this implementation
+1. Since the Google Play Services update v26.03 of January 2026, NFC FIDO2 authenticators with
+   resident credentials and PIN verification are supported for Android 9 and later.
+   The Google Play Services do require the applet to be installed with the `CardReset` privilege
+   as described in [the installation manual](docs/installation.md).
+
+   The system UI still does not allow for changing PIN or deleting credentials, for that you will
+   need an application such as [Authnkey](https://github.com/mimi89999/Authnkey)
+   ([F-Droid](https://f-droid.org/packages/pl.lebihan.authnkey/)
+   / [Google Play](https://f-droid.org/packages/pl.lebihan.authnkey/)).
+
+   Previously, the Google Play Services only supported CTAP1 over the NFC transport which was
+   restricted to the creation of *non-discoverable* credentials for second-factor authentication.
+   MicroG already had a fully-working implementation, though! See https://github.com/microg/GmsCore/pull/2194
+   for PIN support.
+2. Some browsers support FIDO2 in theory but only allow USB security keys - this implementation
    is for PC/SC, and doesn't implement USB HID, so it will only work with FIDO2
    implementations that can handle e.g. NFC tokens instead of being restricted to USB.
    In order to use a smartcard in these situations you'll need https://github.com/StarGate01/CTAP-bridge ,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # Installation Parameters
 
 This applet provides a variety of install-time configurable settings. These are configured via a
-CBOR map provided when the applet is installed (for example, via `gpp --install <applet> --params <params>`).
+CBOR map provided when the applet is installed (for example, via `gp --install <applet> --params <params>`).
 
 To generate the parameter string, use the `get_install_parameters.py` script at the root of the repository.
 The help the script provides (`--help`) explains each options.
@@ -12,3 +12,15 @@ parameters.
 
 If you want attestation to work, you'll also need to run `./install_attestation_cert.py` after installing the
 applet itself!
+
+## Android installation
+
+For the Android installation to work with the native system UI provided by the Google Play Services, the
+applet needs to be the default selected applet on the card.
+
+You can do that with `gp --install <applet> --params <params> --privs CardReset`
+
+The reason is that Google Play Services send the `SELECT` APDU using extended-length encoding while the
+GlobalPlatform manager of JavaCards does not support that.
+By having the applet be the default selected applet, it can bypass GlobalPlatform and handle the `SELECT`
+by itself.

--- a/src/main/java/us/q3q/fido2/FIDO2Applet.java
+++ b/src/main/java/us/q3q/fido2/FIDO2Applet.java
@@ -405,6 +405,10 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
 
+    private static final short IDX_SELECTED = 0;
+
+    private boolean[] transientBooleans;
+
     /**
      * Deliver a particular byte array to the platform
      *
@@ -3470,15 +3474,19 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
         final short cla_ins = Util.getShort(apduBytes, ISO7816.OFFSET_CLA);
         final short p1_p2 = Util.getShort(apduBytes, ISO7816.OFFSET_P1);
 
+        if (cla_ins == (short) 0x00A4 && p1_p2 == (short) 0x0400) {
+            // Applet-select command, either extended-length SELECT or test shenanigans
+            handleAppletSelect(apdu);
+            return;
+        }
+
+        if (!transientBooleans[IDX_SELECTED]) {
+            ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+        }
+
         if (cla_ins == (short) 0x8012 && p1_p2 == (short) 0x0100) {
             // Explicit disable command (NFCCTAP_CONTROL end CTAP_MSG). Turn off, and stay off.
             transientStorage.disableAuthenticator();
-        }
-
-        if (cla_ins == (short) 0x00A4 && p1_p2 == (short) 0x0400) {
-            // Applet-select command, probably part of test shenanigans
-            handleAppletSelect(apdu);
-            return;
         }
 
         if (transientStorage.authenticatorDisabled()) {
@@ -4390,6 +4398,8 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
         } else {
             sendByteArray(apdu, CannedCBOR.U2F_V2_RESPONSE, (short) CannedCBOR.U2F_V2_RESPONSE.length);
         }
+
+        transientBooleans[IDX_SELECTED] = true;
     }
 
     /**
@@ -7018,6 +7028,7 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
         sha256 = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
 
         transientStorage = new TransientStorage();
+        transientBooleans = JCSystem.makeTransientBooleanArray((short)1, JCSystem.CLEAR_ON_DESELECT);
 
         final short availableMem = JCSystem.getAvailableMemory(JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT);
 

--- a/src/main/java/us/q3q/fido2/FIDO2Applet.java
+++ b/src/main/java/us/q3q/fido2/FIDO2Applet.java
@@ -405,10 +405,6 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
 
-    private static final short IDX_SELECTED = 0;
-
-    private boolean[] transientBooleans;
-
     /**
      * Deliver a particular byte array to the platform
      *
@@ -3480,7 +3476,7 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
             return;
         }
 
-        if (!transientBooleans[IDX_SELECTED]) {
+        if (!transientStorage.isAppletSelected()) {
             ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
         }
 
@@ -4399,7 +4395,7 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
             sendByteArray(apdu, CannedCBOR.U2F_V2_RESPONSE, (short) CannedCBOR.U2F_V2_RESPONSE.length);
         }
 
-        transientBooleans[IDX_SELECTED] = true;
+        transientStorage.setAppletSelected();
     }
 
     /**
@@ -7028,7 +7024,6 @@ public final class FIDO2Applet extends Applet implements ExtendedLength {
         sha256 = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
 
         transientStorage = new TransientStorage();
-        transientBooleans = JCSystem.makeTransientBooleanArray((short)1, JCSystem.CLEAR_ON_DESELECT);
 
         final short availableMem = JCSystem.getAvailableMemory(JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT);
 

--- a/src/main/java/us/q3q/fido2/TransientStorage.java
+++ b/src/main/java/us/q3q/fido2/TransientStorage.java
@@ -55,11 +55,11 @@ public final class TransientStorage {
     /**
      * Giant boolean bitfield that holds all the BOOL_IDX variables below
      */
-    private static final byte IDX_BOOLEAN_OMNIBUS = 14; // 1 byte
+    private static final byte IDX_BOOLEAN_OMNIBUS = 14; // 2 bytes
     /**
      * How many bytes long the temp storage should be
      */
-    private static final byte NUM_RESET_BYTES = 15;
+    private static final byte NUM_RESET_BYTES = 16;
 
     // boolean bit indices held in BOOLEAN_OMNIBUS byte above
     /**
@@ -94,6 +94,10 @@ public final class TransientStorage {
      * Set to true when the authenticator app is fully disabled until next reselect
      */
     private static final byte BOOL_IDX_AUTHENTICATOR_DISABLED = 7;
+    /**
+     * Set to true when a SELECT APDU for this applet was received and the applet has not been deselected since
+     */
+    private static final byte BOOL_IDX_APPLET_SELECTED = 8;
 
     public TransientStorage() {
         // Pin-retries-since-reset counter, which must be cleared on RESET, not on deselect, is stored in this array
@@ -106,17 +110,33 @@ public final class TransientStorage {
     }
 
     private boolean getBoolByIdx(byte idx) {
-        return (byte)((tempBytes[IDX_BOOLEAN_OMNIBUS] & (1 << idx))) != 0;
+        short offset = IDX_BOOLEAN_OMNIBUS;
+        if (idx >= 8) {
+            idx -= 8;
+            offset++;
+        }
+        return (byte)(tempBytes[offset] & (1 << idx)) != 0;
     }
 
     private void setBoolByIdx(byte idx, boolean val) {
-        if (val) {
-            tempBytes[IDX_BOOLEAN_OMNIBUS] =
-                    (byte)(tempBytes[IDX_BOOLEAN_OMNIBUS] | (1 << idx));
-        } else {
-            tempBytes[IDX_BOOLEAN_OMNIBUS] =
-                    (byte)(tempBytes[IDX_BOOLEAN_OMNIBUS] & ~(1 << idx));
+        short offset = IDX_BOOLEAN_OMNIBUS;
+        if (idx >= 8) {
+            idx -= 8;
+            offset++;
         }
+        if (val) {
+            tempBytes[offset] = (byte)(tempBytes[offset] | (1 << idx));
+        } else {
+            tempBytes[offset] = (byte)(tempBytes[offset] & ~(1 << idx));
+        }
+    }
+
+    public boolean isAppletSelected() {
+        return getBoolByIdx(BOOL_IDX_APPLET_SELECTED);
+    }
+
+    public void setAppletSelected() {
+        setBoolByIdx(BOOL_IDX_APPLET_SELECTED, true);
     }
 
     public boolean authenticatorDisabled() {


### PR DESCRIPTION
This is in relation to issue #62, this pull request makes it possible to safely process extended-length SELECT APDUs by refusing any command that happens before the SELECT.

The applet needs to be installed as the default selected applet for the contactless interface for this to work, for instance by assigning the `CardReset` privilege during installation.

The selected status is kept in a `CLEAR_ON_DESELECT` transient boolean whose value on reset or after a deselect will always be `false`.